### PR TITLE
Compatibility for the Aether's cape elytra skins.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,8 @@ dependencies {
     compileOnly fg.deobf("curse.maven:netheriteplus-394120:3175587")
 
     runtimeOnly fg.deobf("curse.maven:silentlib-242998:3165746")
+
+    compileOnly fileTree(dir: 'libs', include: '*.jar')
 }
 
 sourceSets {

--- a/src/main/java/top/theillusivec4/curiouselytra/CuriousElytra.java
+++ b/src/main/java/top/theillusivec4/curiouselytra/CuriousElytra.java
@@ -22,6 +22,8 @@ package top.theillusivec4.curiouselytra;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import com.gildedgames.aether.common.item.accessories.cape.CapeItem;
 import net.minecraft.entity.ai.attributes.ModifiableAttributeInstance;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ElytraItem;
@@ -61,6 +63,7 @@ public class CuriousElytra {
 
   public static boolean isNetheritePlusLoaded = false;
   public static boolean isSilentGearLoaded = false;
+  public static boolean isAetherLoaded = false;
 
   public CuriousElytra() {
     IEventBus eventBus = FMLJavaModLoadingContext.get().getModEventBus();
@@ -69,6 +72,7 @@ public class CuriousElytra {
     eventBus.addListener(this::setup);
     isNetheritePlusLoaded = ModList.get().isLoaded("netherite_plus");
     isSilentGearLoaded = ModList.get().isLoaded("silentgear");
+    isAetherLoaded = ModList.get().isLoaded("aether");
   }
 
   private void setup(final FMLCommonSetupEvent evt) {
@@ -152,6 +156,16 @@ public class CuriousElytra {
                   evt.setResourceLocation(new ResourceLocation("mana-and-artifice:textures/entity/elytra.png"));
                   evt.setEnchanted(true);
                 }
+              }
+
+              if (isAetherLoaded) {
+                CuriosApi.getCuriosHelper().findEquippedCurio((item) -> item.getItem() instanceof CapeItem, evt.getPlayer()).ifPresent(triple ->
+                        CuriosApi.getCuriosHelper().getCuriosHandler(evt.getPlayer()).ifPresent(capeHandler -> capeHandler.getStacksHandler(triple.getLeft()).ifPresent(capeStacksHandler -> {
+                          CapeItem cape = (CapeItem) triple.getRight().getItem();
+                          if (cape.getCapeTexture() != null && capeStacksHandler.getRenders().get(triple.getMiddle())) {
+                            evt.setResourceLocation(cape.getCapeTexture());
+                          }
+                        })));
               }
 
               if (stack.isEnchanted()) {


### PR DESCRIPTION
Allows Curious Elytras to work with the Aether's cape elytra skins.

To have this work in the dev environment its gonna require setting up a libs folder in the main workspace directory and putting one of the Aether's alpha jars into it, a download of which can be found here: https://app.circleci.com/pipelines/github/Gilded-Games/The-Aether/297/workflows/767e3060-b632-4e54-932e-eb6c9fb334b9/jobs/302/artifacts.