### PR TITLE
Update fabric mod for 1.19

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.10-SNAPSHOT'
+    id 'fabric-loom' version '0.12-SNAPSHOT'
     id 'com.matthewprenger.cursegradle' version '1.4.0'
 }
 
@@ -9,9 +9,6 @@ targetCompatibility = JavaVersion.VERSION_17
 archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
-
-minecraft {
-}
 
 repositories {
     maven {

--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -2,20 +2,20 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-	minecraft_version=1.18.1
-	yarn_mappings=1.18.1+build.4
-	loader_version=0.12.12
+	minecraft_version=1.19
+	yarn_mappings=1.19+build.2
+	loader_version=0.14.7
 
 # Mod Properties
-	mod_version=3.0.0-1.18.1
+	mod_version=3.0.0-1.19
 	maven_group=top.theillusivec4.elytratrinket
 	archives_base_name=elytratrinket-fabric
 
 # Dependencies
-	fabric_version=0.44.0+1.18
-	trinkets_version=3.1.0
+	fabric_version=0.55.3+1.19
+	trinkets_version=3.4.0
 
 # Curse
 	curse_id=397903
 	curse_release=release
-	curse_versions=1.18.1
+	curse_versions=1.19

--- a/fabric/src/main/java/top/theillusivec4/elytratrinket/ElytraTrinketMod.java
+++ b/fabric/src/main/java/top/theillusivec4/elytratrinket/ElytraTrinketMod.java
@@ -29,7 +29,6 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ElytraItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
 import net.minecraft.util.Pair;
 import net.minecraft.world.event.GameEvent;
 
@@ -57,7 +56,6 @@ public class ElytraTrinketMod implements ModInitializer {
             return true;
           }
         } else if (item instanceof FabricElytraItem fabricElytraItem) {
-
           if (fabricElytraItem.useCustomElytra(entity, stack, tickElytra)) {
             return true;
           }
@@ -75,7 +73,7 @@ public class ElytraTrinketMod implements ModInitializer {
       if ((nextRoll / 10) % 2 == 0) {
         stack.damage(1, entity, p -> TrinketsApi.onTrinketBroken(stack, slotRef, entity));
       }
-      entity.emitGameEvent(GameEvent.ELYTRA_FREE_FALL);
+      entity.emitGameEvent(GameEvent.ELYTRA_GLIDE);
     }
   }
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -23,9 +23,9 @@
   },
   "mixins": [],
   "depends": {
-    "fabricloader": ">=0.11.3",
-    "fabric": ">=0.44.0",
-    "minecraft": "1.18.x",
+    "fabricloader": ">=0.12.3",
+    "fabric": ">=0.55.0",
+    "minecraft": "1.19.x",
     "trinkets": "*"
   }
 }


### PR DESCRIPTION
The mod works fine, the only change was the renaming of ELYTRA_FREE_FALL to ELYTRA_GLIDE.
Some dependencies of the forge mod are still not updated for 1.19, so it will have to wait.