### PR TITLE
Update to 1.19.3

### DIFF
--- a/fabric/src/main/java/com/illusivesoulworks/elytraslot/platform/FabricPlatform.java
+++ b/fabric/src/main/java/com/illusivesoulworks/elytraslot/platform/FabricPlatform.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import org.jetbrains.annotations.NotNull;
@@ -38,12 +38,12 @@ public class FabricPlatform implements IPlatform {
 
   @Override
   public ResourceLocation getId(Item item) {
-    return Registry.ITEM.getKey(item);
+    return BuiltInRegistries.ITEM.getKey(item);
   }
 
   @NotNull
   @Override
   public Set<ResourceLocation> getEntityTypes() {
-    return Registry.ENTITY_TYPE.keySet();
+    return BuiltInRegistries.ENTITY_TYPE.keySet();
   }
 }

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -93,7 +93,7 @@ repositories {
 dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
     compileOnly project(":common")
-    compileOnly "curse.maven:mccapes-359836:4019977"
+    compileOnly "curse.maven:mccapes-359836:4165186"
 
     runtimeOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}")
     compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}:api")

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -93,7 +93,7 @@ repositories {
 dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
     compileOnly project(":common")
-    compileOnly "curse.maven:mccapes-359836:4165186"
+    compileOnly "curse.maven:mccapes-359836:${mccapes_cf_file_id}"
 
     runtimeOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}")
     compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}:api")

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,6 +22,7 @@ curios_version=1.19.3-5.1.2.0
 curios_version_range=[1.19.3-5.1.2.0,)
 caelus_version=1.19.3-3.0.0.7
 caelus_version_range=[1.19.3-3.0.0.7,)
+mccapes_cf_file_id=4165186
 
 # Fabric
 fabric_version=0.73.2+1.19.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,38 +1,38 @@
 # Project
-version=6.1.0+1.19.2
+version=6.2.0+1.19.3
 group=com.illusivesoulworks.elytraslot
 license=LGPL-3.0-or-later
 issue_tracker=https://github.com/illusivesoulworks/elytraslot/issues
 
 # Common
-minecraft_version=1.19.2
+minecraft_version=1.19.3
 common_runs_enabled=false
 common_client_run_name=Common Client
 common_server_run_name=Common Server
 
 # Forge
-forge_version=43.0.7
-forge_version_range=[41,)
-forge_mc_version_range=[1.19,1.20)
-//forge_ats_enabled=true
-forge_parchment_version=1.18.2-2022.08.07-1.19.2
+forge_version=44.1.0
+forge_version_range=[44,)
+forge_mc_version_range=[1.19.3,1.20)
+#forge_ats_enabled=true
+forge_parchment_version=1.18.2-2022.11.06-1.19.3
 
 # Forge Dependencies
-curios_version=1.19.1-5.1.0.5
-curios_version_range=[1.19-5.1.0.0,)
-caelus_version=1.19.1-3.0.0.4
-caelus_version_range=[1.19-3.0.0.3,)
+curios_version=1.19.3-5.1.2.0
+curios_version_range=[1.19.3-5.1.2.0,)
+caelus_version=1.19.3-3.0.0.7
+caelus_version_range=[1.19.3-3.0.0.7,)
 
 # Fabric
-fabric_version=0.59.0+1.19.2
-fabric_mc_version_range=1.19.x
-fabric_loader_version=0.14.9
-fabric_parchment_mc_version=1.18.2
-fabric_parchment_version=2022.08.07
+fabric_version=0.73.2+1.19.3
+fabric_mc_version_range=~1.19.3
+fabric_loader_version=0.14.13
+fabric_parchment_mc_version=1.19.3
+fabric_parchment_version=2022.12.18
 
 # Fabric Dependencies
-trinkets_version=3.4.0
-mod_menu_version=4.0.6
+trinkets_version=3.5.0
+mod_menu_version=5.0.2
 
 # Mod options
 mod_name=Elytra Slot
@@ -44,7 +44,7 @@ mod_description=Adds an accessory slot for the elytra so you can fly and wear ch
 cf_forge_id=317716
 cf_fabric_id=397903
 cf_release=release
-cf_versions=1.19.2,1.19.1,1.19
+cf_versions=1.19.3
 
 # Gradle
 org.gradle.jvmargs=-Xmx3G


### PR DESCRIPTION
The only technical change was renaming the registry class references on the Fabric side.

Also, I moved MinecraftCapes' Curseforge file ID from `forge/build.gradle` to `gradle.properties` to make it more intuitive to update in the future, if need be.

(and I assume the `//` in `gradle.properties` was meant to be a `#`?)