### PR TITLE
Added Clutter compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 Prior to version 6.0.0, this project used MCVERSION-MAJORMOD.MAJORAPI.MINOR.PATCH.
 
+## [6.3.1+1.20.1] - 2023.07.24
+### Added
+- Added Clutter compatibility
+
 ## [6.3.0+1.20.1] - 2023.06.20
 ### Changed
 - Updated to Minecraft 1.20.1

--- a/CHANGELOG_LATEST.md
+++ b/CHANGELOG_LATEST.md
@@ -2,6 +2,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 This is a copy of the changelog for the most recent version. For the full version history, go [here](https://github.com/illusivesoulworks/elytraslot/blob/1.20.x/CHANGELOG.md).
 
-## [6.3.0+1.20.1] - 2023.06.20
-### Changed
-- Updated to Minecraft 1.20.1
+## [6.3.1+1.20.1] - 2023.07.24
+### Added
+- Added Clutter compatibility

--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,8 @@ subprojects {
         }
 
         maven {
-            name = "Ladysnake Libs"
-            url = "https://ladysnake.jfrog.io/artifactory/mods"
+            name = "Ladysnake Mods"
+            url = "https://maven.ladysnake.org/releases"
         }
     }
 

--- a/common/src/main/java/com/illusivesoulworks/elytraslot/common/SimpleCompatibilityProvider.java
+++ b/common/src/main/java/com/illusivesoulworks/elytraslot/common/SimpleCompatibilityProvider.java
@@ -17,6 +17,7 @@
 
 package com.illusivesoulworks.elytraslot.common;
 
+import com.illusivesoulworks.elytraslot.ElytraSlotConstants;
 import com.illusivesoulworks.elytraslot.client.ElytraRenderResult;
 import com.illusivesoulworks.elytraslot.platform.Services;
 import java.util.HashMap;
@@ -79,6 +80,35 @@ public class SimpleCompatibilityProvider implements IElytraProvider {
           }
         }
       }
+
+      if (isLoaded.test("clutter")) {
+        String[] clutterElytras = {
+          "white_butterfly_elytra",
+          "light_gray_butterfly_elytra",
+          "gray_butterfly_elytra",
+          "black_butterfly_elytra",
+          "brown_butterfly_elytra",
+          "red_butterfly_elytra",
+          "orange_butterfly_elytra",
+          "yellow_butterfly_elytra",
+          "lime_butterfly_elytra",
+          "green_butterfly_elytra",
+          "cyan_butterfly_elytra",
+          "light_blue_butterfly_elytra",
+          "blue_butterfly_elytra",
+          "purple_butterfly_elytra",
+          "magenta_butterfly_elytra",
+          "pink_butterfly_elytra",
+          "crimson_butterfly_elytra",
+          "warped_butterfly_elytra",
+          "soul_butterfly_elytra",
+        };
+
+        for (String clutterElytra: clutterElytras) {
+          ID_TO_TEXTURE.put("clutter:" + clutterElytra,
+                  new ResourceLocation("clutter", "textures/entity/" + clutterElytra + ".png"));
+        }
+      }
       init = true;
     }
     return ID_TO_TEXTURE.containsKey(Services.PLATFORM.getId(stack.getItem()).toString());
@@ -101,7 +131,7 @@ public class SimpleCompatibilityProvider implements IElytraProvider {
           rl.toString().equals("deeperdarker:soul_elytra")) {
         return false;
       } else if (Services.PLATFORM.isModLoaded("lilwings") &&
-          rl.getNamespace().equals("lilwings")) {
+              rl.getNamespace().equals("lilwings")) {
         return false;
       }
     }

--- a/fabric/src/main/resources/data/trinkets/tags/items/chest/cape.json
+++ b/fabric/src/main/resources/data/trinkets/tags/items/chest/cape.json
@@ -65,6 +65,82 @@
     {
       "id": "lilwings:grayling_blooming_elytra",
       "required": false
+    },
+    {
+      "id": "clutter:white_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:light_gray_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:gray_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:black_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:brown_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:red_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:orange_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:white_yellow_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:lime_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:green_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:cyan_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:light_blue_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:blue_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:purple_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:magenta_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:pink_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:crimson_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:warped_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:soul_butterfly_elytra",
+      "required": false
     }
   ]
 }

--- a/forge/src/main/resources/data/curios/tags/items/back.json
+++ b/forge/src/main/resources/data/curios/tags/items/back.json
@@ -85,6 +85,82 @@
     {
       "id": "lilwings:grayling_blooming_elytra",
       "required": false
+    },
+    {
+      "id": "clutter:white_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:light_gray_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:gray_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:black_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:brown_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:red_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:orange_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:white_yellow_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:lime_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:green_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:cyan_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:light_blue_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:blue_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:purple_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:magenta_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:pink_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:crimson_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:warped_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:soul_butterfly_elytra",
+      "required": false
     }
   ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Project
-version=6.3.0+1.20.1
+version=6.3.1+1.20.1
 group=com.illusivesoulworks.elytraslot
 license=LGPL-3.0-or-later
 issue_tracker=https://github.com/illusivesoulworks/elytraslot/issues

--- a/quilt/src/main/resources/data/trinkets/tags/items/chest/cape.json
+++ b/quilt/src/main/resources/data/trinkets/tags/items/chest/cape.json
@@ -65,6 +65,82 @@
     {
       "id": "lilwings:grayling_blooming_elytra",
       "required": false
+    },
+    {
+      "id": "clutter:white_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:light_gray_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:gray_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:black_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:brown_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:red_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:orange_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:white_yellow_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:lime_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:green_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:cyan_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:light_blue_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:blue_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:purple_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:magenta_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:pink_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:crimson_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:warped_butterfly_elytra",
+      "required": false
+    },
+    {
+      "id": "clutter:soul_butterfly_elytra",
+      "required": false
     }
   ]
 }


### PR DESCRIPTION
Simply adds the various Elytra's provided by the [Clutter](https://modrinth.com/mod/clutter) mod.

PS. I did have to update the maven repository for Ladysnake from https://ladysnake.jfrog.io/artifactory/mods to https://maven.ladysnake.org/releases. First time ever touching maven, Java and a Minecraft mod so please excuse this if it wasn't necessary, but it seems to have moved and was the only way for me to get it to work.