### PR TITLE
Add support for Netherite Extension's Netherite Elytra

### DIFF
--- a/common/src/main/java/com/illusivesoulworks/elytraslot/client/ElytraSlotLayer.java
+++ b/common/src/main/java/com/illusivesoulworks/elytraslot/client/ElytraSlotLayer.java
@@ -55,7 +55,11 @@ public class ElytraSlotLayer<T extends LivingEntity, M extends EntityModel<T>>
       ResourceLocation resourcelocation;
 
       if (elytra.stack().getItem() instanceof ArmorItem) {
-        return;
+        String itemId = Services.PLATFORM.getId(elytra.stack().getItem()).toString();
+
+        if (!itemId.equals("netherite_ext:netherite_elytra")) {
+          return;
+        }
       }
       Services.CLIENT.processLayerRendering(elytra.stack());
 

--- a/common/src/main/java/com/illusivesoulworks/elytraslot/common/SimpleCompatibilityProvider.java
+++ b/common/src/main/java/com/illusivesoulworks/elytraslot/common/SimpleCompatibilityProvider.java
@@ -104,7 +104,7 @@ public class SimpleCompatibilityProvider implements IElytraProvider {
 
       if (isLoaded.test("netherite_ext")) {
         ID_TO_TEXTURE.put("netherite_ext:netherite_elytra",
-                new ResourceLocation("netherite_ext:textures/entity/netherite_elytra.png"));
+            new ResourceLocation("netherite_ext:textures/entity/netherite_elytra.png"));
       }
       init = true;
     }

--- a/common/src/main/java/com/illusivesoulworks/elytraslot/common/SimpleCompatibilityProvider.java
+++ b/common/src/main/java/com/illusivesoulworks/elytraslot/common/SimpleCompatibilityProvider.java
@@ -101,6 +101,11 @@ public class SimpleCompatibilityProvider implements IElytraProvider {
           }
         }
       }
+
+      if (isLoaded.test("netherite_ext")) {
+        ID_TO_TEXTURE.put("netherite_ext:netherite_elytra",
+                new ResourceLocation("netherite_ext:textures/entity/netherite_elytra.png"));
+      }
       init = true;
     }
     return ID_TO_TEXTURE.containsKey(Services.PLATFORM.getId(stack.getItem()).toString());

--- a/common/src/main/resources/data/elytraslot/tags/items/elytra.json
+++ b/common/src/main/resources/data/elytraslot/tags/items/elytra.json
@@ -105,6 +105,10 @@
     {
       "id": "crystalmod:sapphire_elytra",
       "required": false
+    },
+    {
+      "id": "netherite_ext:netherite_elytra",
+      "required": false
     }
   ]
 }


### PR DESCRIPTION
#163 
I've implemented compatibility with Netherite Extension's Netherite Elytra through minor code adjustments. Would you be able to merge this PR and cut a new release for Minecraft 1.20.1 and above?