### PR TITLE
Update to Minecraft 1.21.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 Prior to version 6.0.0, this project used MCVERSION-MAJORMOD.MAJORAPI.MINOR.PATCH.
 
+## [10.0.1+1.21.8] - 2026.03.03
+### Changed
+- Updated to Minecraft 1.21.8
+
 ## [10.0.1+1.21.4] - 2025.07.23
 ### Changed
 - Updated Caelus API requirement to 8.0.1 to fix an issue with helmets being damaged while gliding with an elytra

--- a/CHANGELOG_LATEST.md
+++ b/CHANGELOG_LATEST.md
@@ -1,8 +1,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-This is a copy of the changelog for the most recent version. For the full version history, go [here](https://github.com/illusivesoulworks/elytraslot/blob/1.21.4/CHANGELOG.md).
+This is a copy of the changelog for the most recent version. For the full version history, go [here](https://github.com/illusivesoulworks/elytraslot/blob/1.21.8/CHANGELOG.md).
 
-## [10.0.1+1.21.4] - 2025.07.23
+## [10.0.1+1.21.8] - 2026.03.03
 ### Changed
-- Updated Caelus API requirement to 8.0.1 to fix an issue with helmets being damaged while gliding with an elytra in a
-curio slot
+- Updated to Minecraft 1.21.8

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     // see https://fabricmc.net/develop/ for new versions
     id 'fabric-loom' version '1.10-SNAPSHOT' apply false
     // see https://projects.neoforged.net/neoforged/moddevgradle for new versions
-    id 'net.neoforged.moddev' version '2.0.89' apply false
+    id 'net.neoforged.moddev' version '2.0.140' apply false
 }
 
 def publishDiscord() {

--- a/fabric/src/main/java/com/illusivesoulworks/elytraslot/ElytraSlotFabricMod.java
+++ b/fabric/src/main/java/com/illusivesoulworks/elytraslot/ElytraSlotFabricMod.java
@@ -19,7 +19,7 @@ package com.illusivesoulworks.elytraslot;
 
 import com.illusivesoulworks.elytraslot.common.AccessoryElytra;
 import io.wispforest.accessories.api.AccessoriesCapability;
-import io.wispforest.accessories.api.AccessoryRegistry;
+import io.wispforest.accessories.api.core.AccessoryRegistry;
 import io.wispforest.accessories.api.slot.SlotEntryReference;
 import io.wispforest.accessories.api.slot.SlotPredicateRegistry;
 import java.util.List;

--- a/fabric/src/main/java/com/illusivesoulworks/elytraslot/common/AccessoryElytra.java
+++ b/fabric/src/main/java/com/illusivesoulworks/elytraslot/common/AccessoryElytra.java
@@ -1,6 +1,6 @@
 package com.illusivesoulworks.elytraslot.common;
 
-import io.wispforest.accessories.api.Accessory;
+import io.wispforest.accessories.api.core.Accessory;
 import io.wispforest.accessories.api.slot.SlotReference;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.ItemStack;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 # Project
-version=10.0.1+1.21.4
+version=10.0.1+1.21.8
 group=com.illusivesoulworks.elytraslot
 java_version=21
 
 # Common
-minecraft_version=1.21.4
+minecraft_version=1.21.8
 mod_name=Elytra Slot
 mod_author=Illusive Soulworks
 mod_id=elytraslot
@@ -12,33 +12,33 @@ license=LGPL-3.0-or-later
 issues_url=https://github.com/illusivesoulworks/elytraslot/issues
 sources_url=https://github.com/illusivesoulworks/elytraslot
 description=Adds an accessory slot for the elytra, so you can fly and wear chest armor at the same time.
-minecraft_version_range=[1.21.4, 1.22)
-minecraft_version_range_alt=~1.21.4
+minecraft_version_range=[1.21.8, 1.22)
+minecraft_version_range_alt=~1.21.8
 
 ## This is the version of minecraft that the 'common' project uses, you can find a list of all versions here
 ## https://projects.neoforged.net/neoforged/neoform
-neo_form_version=1.21.4-20241203.161809
+neo_form_version=1.21.8-20250717.133445
 
 # The version of ParchmentMC that is used, see https://parchmentmc.org/docs/getting-started#choose-a-version for new versions
-parchment_mc=1.21.4
-parchment_version=2025.03.23
+parchment_mc=1.21.8
+parchment_version=2025.07.20
 
 # Fabric
-fabric_version=0.113.0+1.21.4
-fabric_loader_version=0.16.9
+fabric_version=0.129.0+1.21.8
+fabric_loader_version=0.16.14
 
 # Fabric Dependencies
 trinkets_version=3.10.0
-accessories_version=1.2.19-beta+1.21.4
-mod_menu_version=13.0.3
+accessories_version=1.3.8-beta+1.21.8
+mod_menu_version=15.0.0-beta.3
 
 # NeoForge
-neoforge_version=21.4.136
-neoforge_version_range=[21.4.123,)
+neoforge_version=21.8.52
+neoforge_version_range=[21.8.9,)
 
 # NeoForge Dependencies
-curios_version=10.0.1+1.21.4
-curios_version_range=[7.0.0,)
+curios_version=12.0.0+1.21.8
+curios_version_range=[12.0.0,)
 caelus_version=8.0.1+1.21.4
 caelus_version_range=[8.0.1,)
 mccapes_cf_file_id=5966373
@@ -49,8 +49,8 @@ cf_page=https://www.curseforge.com/minecraft/mc-mods/elytra-slot
 modrinth_id=mSQF1NpT
 modrinth_page=https://modrinth.com/mod/elytra-slot
 release_type=release
-release_versions=1.21.5,1.21.4
-changelog_link=https://github.com/illusivesoulworks/elytraslot/blob/1.21.4/CHANGELOG.md
+release_versions=1.21.8
+changelog_link=https://github.com/illusivesoulworks/elytraslot/blob/1.21.8/CHANGELOG.md
 discord_thumbnail=https://media.forgecdn.net/avatars/209/40/636979175379460863.png
 
 # Gradle


### PR DESCRIPTION
## Summary
- Update project version and Minecraft target to 1.21.8.
- Refresh Fabric/NeoForge dependency versions and ranges for 1.21.8 compatibility.
- Update changelog files and changelog link for the 10.0.1+1.21.8 release.