### PR TITLE
Fix Deeper Darker 1.4 compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Project
-version=9.0.2+1.21.1
+version=9.0.3+1.21.1
 group=com.illusivesoulworks.elytraslot
 java_version=21
 

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     runtimeOnly "com.illusivesoulworks.caelus:caelus-neoforge:${caelus_version}"
     compileOnly "com.illusivesoulworks.caelus:caelus-neoforge:${caelus_version}:api"
 
-    compileOnly "curse.maven:deeperdarker-659011:5698218"
+    compileOnly "curse.maven:deeperdarker-659011:7940538"
 }
 
 task publishCurseForge(type: TaskPublishCurseForge) {

--- a/neoforge/src/main/java/com/illusivesoulworks/elytraslot/common/integration/deeperdarker/DeeperDarkerPlugin.java
+++ b/neoforge/src/main/java/com/illusivesoulworks/elytraslot/common/integration/deeperdarker/DeeperDarkerPlugin.java
@@ -47,7 +47,7 @@ public class DeeperDarkerPlugin {
         float percent = player.getCooldowns().getCooldownPercent(DDItems.SOUL_ELYTRA.get(), 0);
         player.displayClientMessage(
             Component.translatable("item." + DeeperDarker.MOD_ID + ".soul_elytra.cooldown",
-                (int) Math.ceil(percent * DeeperDarkerConfig.soulElytraCooldown / 20)), true);
+                (int) Math.ceil(percent * DeeperDarkerConfig.CONFIG.soulElytraCooldown.getAsInt() / 20)), true);
       }
     }
   }

--- a/neoforge/src/main/java/com/illusivesoulworks/elytraslot/common/integration/deeperdarker/SoulElytraBoostPayload.java
+++ b/neoforge/src/main/java/com/illusivesoulworks/elytraslot/common/integration/deeperdarker/SoulElytraBoostPayload.java
@@ -42,7 +42,7 @@ public record SoulElytraBoostPayload(boolean bool) implements CustomPacketPayloa
       Player player = context.player();
       Level level = player.level();
 
-      if (DeeperDarkerConfig.soulElytraCooldown == -1) {
+      if (DeeperDarkerConfig.CONFIG.soulElytraCooldown.getAsInt() == -1) {
         player.displayClientMessage(
             Component.translatable("item." + DeeperDarker.MOD_ID + ".soul_elytra.no_cooldown"),
             true);
@@ -55,7 +55,7 @@ public record SoulElytraBoostPayload(boolean bool) implements CustomPacketPayloa
             new FireworkRocketEntity(level, new ItemStack(Items.FIREWORK_ROCKET), player);
         level.addFreshEntity(rocket);
         player.getCooldowns()
-            .addCooldown(DDItems.SOUL_ELYTRA.get(), DeeperDarkerConfig.soulElytraCooldown);
+            .addCooldown(DDItems.SOUL_ELYTRA.get(), DeeperDarkerConfig.CONFIG.soulElytraCooldown.getAsInt());
       }
     });
   }


### PR DESCRIPTION
`DeeperDarkerConfig.soulElytraCooldown` was moved into a `CONFIG` holder in 1.4, which broke our integration with a `NoSuchFieldError` at runtime. Switch to the new accessor and bump the `compileOnly` dependency.

---

**Note (not in this PR):** to get the project to compile locally on Java 21 I also had to:

- Pin `net.darkhax.curseforgegradle` from `'1.+'` to `'1.1.28'` in the loader `build.gradle` files — version `1.2.30` was published on 2026-03-26 targeting Java 25, so the floating `1.+` resolves to a plugin Gradle 8.8 / Java 21 can no longer load.
- Change `token = findProperty('modrinthKey') ?: 0` to `?: ''` in the `modrinth { }` blocks — the Integer fallback fails the typed `String token` property check on the current Modrinth Minotaur plugin.

I left those out of this PR to keep the diff focused on the actual bug fix, but happy to follow up with a separate PR if you'd like them addressed too.